### PR TITLE
Force 24bit resampling

### DIFF
--- a/sound/core/oss/pcm_plugin.c
+++ b/sound/core/oss/pcm_plugin.c
@@ -413,7 +413,7 @@ int snd_pcm_plug_format_plugins(struct snd_pcm_substream *plug,
 	    ! snd_pcm_format_linear(srcformat.format)) {
 		if (srcformat.format != SNDRV_PCM_FORMAT_MU_LAW)
 			return -EINVAL;
-		tmpformat.format = SNDRV_PCM_FORMAT_S16;
+		tmpformat.format = SNDRV_PCM_FORMAT_S24;
 		err = snd_pcm_plugin_build_mulaw(plug,
 						 &srcformat, &tmpformat,
 						 &plugin);
@@ -446,9 +446,9 @@ int snd_pcm_plug_format_plugins(struct snd_pcm_substream *plug,
 
 	/* rate resampling */
 	if (!rate_match(srcformat.rate, dstformat.rate)) {
-		if (srcformat.format != SNDRV_PCM_FORMAT_S16) {
-			/* convert to S16 for resampling */
-			tmpformat.format = SNDRV_PCM_FORMAT_S16;
+		if (srcformat.format != SNDRV_PCM_FORMAT_S32) {
+			/* convert to S24, ever 24bit playback for now */
+			tmpformat.format = SNDRV_PCM_FORMAT_S24;
 			err = snd_pcm_plugin_build_linear(plug,
 							  &srcformat, &tmpformat,
 							  &plugin);


### PR DESCRIPTION
Added 24bit resampling, now 24bit is permanent available also without Audioflinger (Audio HAL)
